### PR TITLE
Remove focus border from search textarea for cleaner UX

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -7,7 +7,7 @@
       :value="modelValue"
       :placeholder="placeholder"
       rows="3"
-      class="w-full border-none outline-none text-base text-text-primary placeholder-text-muted bg-transparent resize-none p-0 overflow-hidden"
+      class="w-full border-none outline-none text-base text-text-primary placeholder-text-muted bg-transparent resize-none p-0 overflow-hidden focus:outline-none focus:ring-0 focus:border-none"
       @input="handleInput"
       @keypress.enter.prevent="handleSearch"
     ></textarea>


### PR DESCRIPTION
- Add focus:outline-none, focus:ring-0, and focus:border-none classes
- Eliminates visual border when textarea is focused or selected
- Provides seamless typing experience without distracting outline

🤖 Generated with [Claude Code](https://claude.ai/code)