### PR TITLE
Update DetailedResultCard layout and styling improvements

### DIFF
--- a/src/components/search/DetailedResultCard.vue
+++ b/src/components/search/DetailedResultCard.vue
@@ -89,7 +89,11 @@
               <div class="text-xs text-text-secondary">
                 {{ person.stats.netWorth.split(' ').slice(1).join(' ') }}
               </div>
-              <div class="text-xs text-brand-orange">Reference</div>
+              <button
+                class="text-xs text-brand-orange hover:underline cursor-pointer"
+              >
+                Reference
+              </button>
             </div>
 
             <!-- Spouse -->
@@ -109,8 +113,9 @@
 
       <!-- Accounts Section -->
       <div>
-        <h3 class="text-sm font-medium text-text-primary mb-3">Accounts</h3>
-        <div class="flex gap-3">
+        <div class="flex flex-wrap items-center gap-3">
+          <h3 class="text-lg font-bold text-text-primary">Accounts</h3>
+          <div class="w-4"></div>
           <!-- Instagram -->
           <div
             class="w-10 h-10 bg-pink-500 rounded-lg flex items-center justify-center"
@@ -153,16 +158,8 @@
               />
             </svg>
           </div>
-          <!-- Additional placeholder accounts -->
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-          <div class="w-10 h-10 bg-gray-300 rounded-lg"></div>
-        </div>
-        <div class="mt-3">
-          <button class="text-sm text-brand-orange hover:underline">
+          <!-- Login Button -->
+          <button class="text-sm text-brand-orange hover:underline ml-3">
             Login for more details →
           </button>
         </div>

--- a/src/components/search/__tests__/DetailedResultCard.accessibility.test.ts
+++ b/src/components/search/__tests__/DetailedResultCard.accessibility.test.ts
@@ -27,7 +27,7 @@ describe('DetailedResultCard Accessibility', () => {
     imageCount: 21,
     stats: {
       age: '26',
-      netWorth: '$1,890 M USD (2022)'
+      netWorth: '$1.890 M USD (2022)'
     },
     personal: {
       birthDate: '10 Aug 2000',
@@ -181,10 +181,11 @@ describe('DetailedResultCard Accessibility', () => {
       // All section headings should be h3 elements
       headings.forEach(heading => {
         expect(heading.element.tagName).toBe('H3')
-        // Some headings use font-semibold, others use font-medium
+        // Some headings use font-semibold, font-medium, or font-bold
         expect(
           heading.classes().includes('font-semibold') ||
-            heading.classes().includes('font-medium')
+            heading.classes().includes('font-medium') ||
+            heading.classes().includes('font-bold')
         ).toBe(true)
       })
     })
@@ -196,7 +197,8 @@ describe('DetailedResultCard Accessibility', () => {
         // Consistent typography for screen readers and visual users
         expect(
           heading.classes().includes('font-semibold') ||
-            heading.classes().includes('font-medium')
+            heading.classes().includes('font-medium') ||
+            heading.classes().includes('font-bold')
         ).toBe(true)
         expect(heading.classes()).toContain('text-text-primary')
       })
@@ -270,9 +272,11 @@ describe('DetailedResultCard Accessibility', () => {
       )
       expect(knowMoreLink.exists()).toBe(true)
 
-      const loginButton = wrapper.find('button')
-      expect(loginButton.exists()).toBe(true)
-      expect(loginButton.text()).toContain('Login for more details')
+      const loginButton = wrapper
+        .findAll('button')
+        .find(btn => btn.text().includes('Login for more details'))
+      expect(loginButton?.exists()).toBe(true)
+      expect(loginButton?.text()).toContain('Login for more details')
     })
 
     it('should provide appropriate focus indicators', () => {

--- a/src/components/search/__tests__/DetailedResultCard.test.ts
+++ b/src/components/search/__tests__/DetailedResultCard.test.ts
@@ -18,7 +18,7 @@ describe('DetailedResultCard', () => {
     imageCount: 21,
     stats: {
       age: '26',
-      netWorth: '$1,890 M USD (2022)'
+      netWorth: '$1.890 M USD (2022)'
     },
     personal: {
       birthDate: '10 Aug 2000',
@@ -152,7 +152,7 @@ describe('DetailedResultCard', () => {
 
     expect(wrapper.text()).toContain('26')
     expect(wrapper.text()).toContain('Age')
-    expect(wrapper.text()).toContain('$1,890')
+    expect(wrapper.text()).toContain('$1.890')
     expect(wrapper.text()).toContain('Net Worth')
   })
 

--- a/src/test/integration/SearchDetailWorkflow.test.ts
+++ b/src/test/integration/SearchDetailWorkflow.test.ts
@@ -236,7 +236,7 @@ describe('SearchDetail Integration Tests', () => {
     // Check age and net worth stats
     expect(wrapper.text()).toContain('26')
     expect(wrapper.text()).toContain('Age')
-    expect(wrapper.text()).toContain('$1,890')
+    expect(wrapper.text()).toContain('$1.890')
     expect(wrapper.text()).toContain('Net Worth')
   })
 

--- a/src/views/SearchDetail.vue
+++ b/src/views/SearchDetail.vue
@@ -105,7 +105,7 @@
     imageCount: 21,
     stats: {
       age: '26',
-      netWorth: '$1,890 M USD (2022)'
+      netWorth: '$1.890 M USD (2022)'
     },
     personal: {
       birthDate: '10 Aug 2000',


### PR DESCRIPTION
- Reposition login button to appear next to social media icons with responsive wrapping
- Update "Accounts" heading to bold 18pt font and position to left of icons
- Change net worth format from "$1,890 M USD" to "$1.890 M USD"
- Convert "Reference" text to clickable button element
- Remove 6 empty placeholder containers from accounts section
- Update tests to match new styling patterns and layout changes

🤖 Generated with [Claude Code](https://claude.ai/code)