### PR TITLE
Fix URL routing to remove hash symbols

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue'
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import Landing from './views/Landing.vue'
@@ -14,7 +14,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes
 })
 


### PR DESCRIPTION
- Replace createWebHashHistory with createWebHistory for clean URLs
- URLs now display as /search instead of /#/search
- Improves SEO and user experience with professional-looking URLs
- Requires history mode fallback configuration in production

🤖 Generated with [Claude Code](https://claude.ai/code)