### PR TITLE
Fix conversation panel consistency between search results and detail …

### DIFF
--- a/src/components/search/__tests__/CategoryTabs.accessibility.test.ts
+++ b/src/components/search/__tests__/CategoryTabs.accessibility.test.ts
@@ -51,6 +51,10 @@ describe('CategoryTabs Accessibility', () => {
   })
 
   it('provides keyboard navigation for tabs', async () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     const professionalTab = wrapper
@@ -80,6 +84,10 @@ describe('CategoryTabs Accessibility', () => {
   })
 
   it('provides accessible color contrast for tabs', () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     // Active tab should have sufficient contrast

--- a/src/components/search/__tests__/CategoryTabs.test.ts
+++ b/src/components/search/__tests__/CategoryTabs.test.ts
@@ -59,6 +59,10 @@ describe('CategoryTabs', () => {
   })
 
   it('switches to professional tab when clicked', async () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     const professionalTab = wrapper
@@ -125,6 +129,10 @@ describe('CategoryTabs', () => {
   })
 
   it('applies correct styling to inactive tabs', () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     const professionalTab = wrapper
@@ -159,6 +167,10 @@ describe('CategoryTabs', () => {
   })
 
   it('maintains proper tab state when switching between tabs', async () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     // Switch to Professional
@@ -178,6 +190,10 @@ describe('CategoryTabs', () => {
   })
 
   it('renders section headers in tab content', async () => {
+    // Set subscription level to Standard (2) to ensure Professional tab is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(CategoryTabs, { props: mockProps })
 
     // Check Personal tab headers

--- a/src/components/search/__tests__/DetailedResultCard.test.ts
+++ b/src/components/search/__tests__/DetailedResultCard.test.ts
@@ -178,6 +178,10 @@ describe('DetailedResultCard', () => {
   })
 
   it('renders professional information section', () => {
+    // Set subscription level to Standard (2) to ensure Professional content is accessible
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(DetailedResultCard, {
       props: { person: mockPerson }
     })

--- a/src/test/integration/SearchDetailWorkflow.test.ts
+++ b/src/test/integration/SearchDetailWorkflow.test.ts
@@ -149,6 +149,11 @@ describe('SearchDetail Integration Tests', () => {
   })
 
   it('shows detailed person information in DetailedResultCard', async () => {
+    // Set subscription level to Standard (2) to ensure Professional content is accessible
+    const { useSubscriptionStore } = await import('@/stores/subscription')
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(SearchDetail, {
       global: {
         plugins: [router, pinia]
@@ -181,6 +186,11 @@ describe('SearchDetail Integration Tests', () => {
   })
 
   it('allows tab switching in category section', async () => {
+    // Set subscription level to Standard (2) to ensure Professional content is accessible
+    const { useSubscriptionStore } = await import('@/stores/subscription')
+    const subscriptionStore = useSubscriptionStore()
+    subscriptionStore.setLevel(2)
+
     const wrapper = mount(SearchDetail, {
       global: {
         plugins: [router, pinia]

--- a/src/views/SearchDetail.vue
+++ b/src/views/SearchDetail.vue
@@ -345,6 +345,72 @@
       // In real app: loadPersonData(personId)
     }
 
+    // If conversation is empty (cleared from landing), rebuild the default conversation
+    if (
+      conversationStore.conversationHistory.length === 0 &&
+      searchStore.currentQuery
+    ) {
+      // Rebuild the default conversation with the current search query
+      conversationStore.addMessage({
+        id: 'user-message-1',
+        sender: 'user',
+        timestamp: new Date(),
+        content: searchStore.currentQuery
+      })
+
+      conversationStore.addMessage({
+        id: 'system-response-1',
+        sender: 'system',
+        timestamp: new Date(),
+        items: [
+          {
+            id: 'results-summary',
+            type: 'results-summary',
+            resultCount: searchStore.displayTotalResults
+          },
+          {
+            id: 'text-1',
+            type: 'text',
+            content:
+              "Alternatively, you can use the hints below for finding the person you're looking for.",
+            emphasis: 'secondary'
+          },
+          {
+            id: 'hints-group-1',
+            type: 'hints-group',
+            hints: [
+              {
+                text: `What specific details about ${searchStore.currentQuery} can help narrow the search`,
+                onClick: () => {}
+              },
+              {
+                text: `Location or workplace information for ${searchStore.currentQuery}`,
+                onClick: () => {}
+              },
+              {
+                text: `Additional context about ${searchStore.currentQuery}`,
+                onClick: () => {}
+              }
+            ]
+          },
+          {
+            id: 'text-2',
+            type: 'text',
+            content:
+              'Or include further information, such as any documents you may have about him, web links, pictures, or videos; if so, submit them by using the upload option.',
+            emphasis: 'secondary'
+          },
+          {
+            id: 'action-button-1',
+            type: 'action-button',
+            text: 'create a filter using the details that you provided',
+            variant: 'dashed',
+            onClick: () => {}
+          }
+        ]
+      })
+    }
+
     // Show upsell popup when user navigates to detail page
     // Only show if user is not already at maximum subscription level
     // Small delay to let the page render first

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -6,14 +6,19 @@
     @speech-error="handleSpeechError"
   >
     <!-- Hotkey Display -->
-    <div class="absolute top-4 right-4 z-10 bg-gray-800 text-white p-3 rounded-lg shadow-lg text-sm">
+    <div
+      class="absolute top-4 right-4 z-10 bg-gray-800 text-white p-3 rounded-lg shadow-lg text-sm"
+    >
       <div class="font-semibold mb-2">Keyboard Shortcuts</div>
       <div class="space-y-1">
         <div class="flex justify-between items-center gap-4">
           <span class="text-gray-300">Toggle view:</span>
           <kbd class="px-2 py-1 bg-gray-700 rounded text-xs">R</kbd>
         </div>
-        <div v-if="displayMode === 'timeline'" class="flex justify-between items-center gap-4">
+        <div
+          v-if="displayMode === 'timeline'"
+          class="flex justify-between items-center gap-4"
+        >
           <span class="text-gray-300">Rotate timeline:</span>
           <div class="flex gap-1">
             <kbd class="px-2 py-1 bg-gray-700 rounded text-xs">Ctrl+V</kbd>


### PR DESCRIPTION
…pages

- Add conversation rebuilding logic to SearchDetail.vue to match SearchResults.vue
- Fix subscription level dependencies in CategoryTabs and DetailedResultCard tests
- Update integration tests with proper subscription level setup for professional content
- Ensure both pages display same conversation content with shared state
- All 1,474 tests now passing with consistent subscription-gated content behavior

🤖 Generated with [Claude Code](https://claude.ai/code)